### PR TITLE
Store claimed identifier in session

### DIFF
--- a/googleapps.coffee
+++ b/googleapps.coffee
@@ -19,6 +19,7 @@ module.exports = (domain, options = {}) ->
 
           req.session.authenticated = true
           req.session.user = result.email
+          req.session.claimedIdentifier = result.claimedIdentifier
           res.writeHead 302, Location: req.session.returnTo || '/'
           req.session.returnTo = null
           return res.end()

--- a/googleapps.js
+++ b/googleapps.js
@@ -26,6 +26,7 @@
             }
             req.session.authenticated = true;
             req.session.user = result.email;
+            req.session.claimedIdentifier = result.claimedIdentifier;
             res.writeHead(302, {
               Location: req.session.returnTo || '/'
             });


### PR DESCRIPTION
In theory, the user's identifier is claimed identifier, not email address.

Sample issue in current implementation is..
- Users will lose their account when their email address has been changed by google apps manager.
- Another users will get the original user's account if email address is recycled.
  etc.
